### PR TITLE
encoing based on dictionnary (with hot reload) and more settings

### DIFF
--- a/DictionaryAutoComplete.sublime-settings
+++ b/DictionaryAutoComplete.sublime-settings
@@ -1,7 +1,16 @@
 {
 	// If you use another dictionary than the standard en_US,
 	// set the encoding here to whatever your dictionary file uses.
-	// Hint: Try "UTF-8"!
+	// Examples: "UTF-8", "ISO-8859-1"
 	// After you change this, you have to restart Sublime!
-	"encoding": "ISO-8859-1"
+	"encoding": {
+    "Bulgarian" : "UTF-8",
+    "en_US"     : "ISO-8859-1",
+    "en_GB"     : "ISO-8859-1",
+    "French"    : "UTF-8"
+  },
+  // insert the original autocomplete list "before", "after or "none"
+  "insert original": "before",
+  // the maximal number of suggestions
+  "max num results": 1000,
 }


### PR DESCRIPTION
In this version : 
- if we change the dictionary the auto completion list is reloaded
- the encoding can be different for different dictionaries
- there is a new parameter `insert original` that allows to append the original auto completion list (with the words based on the current view). It can takes the values `before`, `after` and `none`.
- there is new parameter `max num results`  that limit the number of results in the suggestion list
- the initialisation is done by `on_activated_async` and not by `on_modified` any more
- some other minor modifications are also done